### PR TITLE
Expose additional api's for consumption

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,7 @@ const sharedConfig = {
     transform: {
         // use typescript to convert from esm to cjs
         '[.](m|c)?(ts|js)(x)?$': ['ts-jest', {
-            'isolatedModules': true,
+            'isolatedModules': false,
         }],
     },
     // any tests that operate on dist files shouldn't compile them again.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,7 @@ const sharedConfig = {
     transform: {
         // use typescript to convert from esm to cjs
         '[.](m|c)?(ts|js)(x)?$': ['ts-jest', {
-            'isolatedModules': false,
+            'isolatedModules': true,
         }],
     },
     // any tests that operate on dist files shouldn't compile them again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.0",
+  "version": "18.0.1-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.0",
+      "version": "18.0.1-pre.1",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.0",
+  "version": "18.0.1-pre.1",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/src/expression/parsing_context.ts
+++ b/src/expression/parsing_context.ts
@@ -192,8 +192,9 @@ class ParsingContext {
     /**
      * Returns null if `t` is a subtype of `expected`; otherwise returns an
      * error message and also pushes it to `this.errors`.
-     * @param expected
-     * @param t
+     * @param expected The expected type
+     * @param t The actual type
+     * @returns null if `t` is a subtype of `expected`; otherwise returns an error message
      */
     checkSubtype(expected: Type, t: Type): string {
         const error = checkSubtype(expected, t);

--- a/src/migrate/expressions.ts
+++ b/src/migrate/expressions.ts
@@ -9,7 +9,8 @@ import type {FilterSpecification, LayerSpecification, StyleSpecification} from '
  * Migrate the given style object in place to use expressions. Specifically,
  * this will convert (a) "stop" functions, and (b) legacy filters to their
  * expression equivalents.
- * @param style
+ * @param style The style object to migrate.
+ * @returns The migrated style object.
  */
 export default function expressions(style: StyleSpecification) {
     const converted = [];

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -89,7 +89,7 @@ import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './til
 import EvaluationContext from './expression/evaluation_context';
 import {FormattedType, NullType, Type, toString} from './expression/types';
 
-import interpolates, {number, color, array, padding, interpolateFactory} from './util/interpolate';
+import interpolates, {interpolateFactory} from './util/interpolate';
 import expressions from './expression/definitions';
 import Interpolate from './expression/definitions/interpolate';
 import type {InterpolationType} from './expression/definitions/interpolate';

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -69,7 +69,7 @@ import latest from './reference/latest';
 import format from './format';
 import migrate from './migrate';
 import derefLayers from './deref';
-import diff, {operations as diffOperations} from './diff';
+import diff, {operations} from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
 import {FeatureState, StyleExpression, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction, Feature, GlobalProperties, SourceExpression, CompositeExpression, StylePropertyExpression} from './expression';
@@ -85,7 +85,7 @@ import {eachSource, eachLayer, eachProperty} from './visit';
 import ResolvedImage from './expression/types/resolved_image';
 import validate from './validate_style';
 import {supportsPropertyExpression} from './util/properties';
-import {number} from './util/interpolate';
+import {range} from './util/interpolate';
 import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './tiles_and_coordinates';
 import EvaluationContext from './expression/evaluation_context';
 import {FormattedType, NullType, Type, toString} from './expression/types';
@@ -106,14 +106,14 @@ import CompoundExpression from './expression/compound_expression';
 
 const expression = {
     StyleExpression,
-    isExpression,
-    isExpressionFilter,
-    createExpression,
-    createPropertyExpression,
-    normalizePropertyExpression,
+    StylePropertyFunction,
     ZoomConstantExpression,
     ZoomDependentExpression,
-    StylePropertyFunction
+    createExpression,
+    createPropertyExpression,
+    isExpression,
+    isExpressionFilter,
+    normalizePropertyExpression,
 };
 
 const styleFunction = {
@@ -122,39 +122,20 @@ const styleFunction = {
     isFunction
 };
 
-const visit = {eachSource, eachLayer, eachProperty};
+const visit = {eachLayer, eachProperty, eachSource};
 
 export {
-    v8,
-    number,
-    interpolate,
     Interpolate,
     InterpolationType,
-    latest,
-    format,
-    emptyStyle,
-    migrate,
-    expressions,
-    derefLayers,
-    diff,
-    diffOperations,
-    supportsPropertyExpression,
     ValidationError,
-    createExpression,
     ParsingError,
-    expression,
-    featureFilter,
     FeatureState,
-    convertFilter,
     Color,
     Step,
     CompoundExpression,
     Padding,
     Formatted,
     ResolvedImage,
-    styleFunction as function,
-    validate,
-    visit,
     Feature,
     EvaluationContext,
     GlobalProperties,
@@ -166,23 +147,44 @@ export {
     ILngLat,
     ILngLatLike,
     StyleExpression,
-    groupByLayout,
     ZoomConstantExpression,
-    NullType,
-    validateStyleMin,
-    Type,
-    normalizePropertyExpression,
-    StylePropertyExpression,
-    isExpression,
-    ZoomDependentExpression,
-    FormattedType,
-    convertFunction,
-    isFunction, createFunction,
-    typeOf,
-    FormatExpression,
     Literal,
-    createPropertyExpression,
+    Type,
     StylePropertyFunction,
-    toString
+    StylePropertyExpression,
+    ZoomDependentExpression,
+    FormatExpression,
 
+    latest,
+    interpolate,
+
+    validate,
+    range,
+    validateStyleMin,
+    groupByLayout,
+    emptyStyle,
+    format,
+    migrate,
+    derefLayers,
+    normalizePropertyExpression,
+    isExpression,
+    diff,
+    supportsPropertyExpression,
+    convertFunction,
+    createExpression,
+    isFunction, createFunction,
+    createPropertyExpression,
+    convertFilter,
+    featureFilter,
+    typeOf,
+    toString,
+
+    v8,
+    NullType,
+    styleFunction as function,
+    visit,
+    operations,
+    expressions,
+    expression,
+    FormattedType,
 };

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -89,7 +89,7 @@ import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './til
 import EvaluationContext from './expression/evaluation_context';
 import {FormattedType, NullType, Type, toString} from './expression/types';
 
-import {range, color, array, padding} from './util/interpolate';
+import {number, color, array, padding} from './util/interpolate';
 import expressions from './expression/definitions';
 import Interpolate from './expression/definitions/interpolate';
 import type {InterpolationType} from './expression/definitions/interpolate';
@@ -103,9 +103,9 @@ import FormatExpression from './expression/definitions/format';
 import Literal from './expression/definitions/literal';
 import CompoundExpression from './expression/compound_expression';
 
-const interpolateFactory = (interpolationType: 'range'|'color'|'array'|'padding') => {
+const interpolateFactory = (interpolationType: 'number'|'color'|'array'|'padding') => {
     switch (interpolationType) {
-        case 'range': return range;
+        case 'number': return number;
         case 'color': return color;
         case 'array': return array;
         case 'padding': return padding;
@@ -167,7 +167,7 @@ export {
 
     interpolateFactory,
     validate,
-    range,
+    number as range,
     validateStyleMin,
     groupByLayout,
     emptyStyle,

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -85,12 +85,11 @@ import {eachSource, eachLayer, eachProperty} from './visit';
 import ResolvedImage from './expression/types/resolved_image';
 import validate from './validate_style';
 import {supportsPropertyExpression} from './util/properties';
-import {range} from './util/interpolate';
 import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './tiles_and_coordinates';
 import EvaluationContext from './expression/evaluation_context';
 import {FormattedType, NullType, Type, toString} from './expression/types';
 
-import * as interpolate from './util/interpolate';
+import {range, color, array, padding} from './util/interpolate';
 import expressions from './expression/definitions';
 import Interpolate from './expression/definitions/interpolate';
 import type {InterpolationType} from './expression/definitions/interpolate';
@@ -103,6 +102,15 @@ import {typeOf} from './expression/values';
 import FormatExpression from './expression/definitions/format';
 import Literal from './expression/definitions/literal';
 import CompoundExpression from './expression/compound_expression';
+
+const interpolateFactory = (interpolationType: 'range'|'color'|'array'|'padding') => {
+    switch (interpolationType) {
+        case 'range': return range;
+        case 'color': return color;
+        case 'array': return array;
+        case 'padding': return padding;
+    }
+};
 
 const expression = {
     StyleExpression,
@@ -156,8 +164,8 @@ export {
     FormatExpression,
 
     latest,
-    interpolate,
 
+    interpolateFactory,
     validate,
     range,
     validateStyleMin,

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -69,20 +69,40 @@ import latest from './reference/latest';
 import format from './format';
 import migrate from './migrate';
 import derefLayers from './deref';
-import diff from './diff';
+import diff, {operations as diffOperations} from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
-import {StyleExpression, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction} from './expression';
+import {FeatureState, StyleExpression, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction, Feature, GlobalProperties, SourceExpression, CompositeExpression, StylePropertyExpression} from './expression';
 import featureFilter, {isExpressionFilter} from './feature_filter';
 
 import convertFilter from './feature_filter/convert';
 import Color from './util/color';
 import Padding from './util/padding';
+import Formatted, {FormattedSection} from './expression/types/formatted';
 import {createFunction, isFunction} from './function';
 import convertFunction from './function/convert';
 import {eachSource, eachLayer, eachProperty} from './visit';
-
+import ResolvedImage from './expression/types/resolved_image';
 import validate from './validate_style';
+import {supportsPropertyExpression} from './util/properties';
+import {number} from './util/interpolate';
+import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './tiles_and_coordinates';
+import EvaluationContext from './expression/evaluation_context';
+import {FormattedType, NullType, Type, toString} from './expression/types';
+
+import * as interpolate from './util/interpolate';
+import expressions from './expression/definitions';
+import Interpolate from './expression/definitions/interpolate';
+import type {InterpolationType} from './expression/definitions/interpolate';
+
+import groupByLayout from './group_by_layout';
+import emptyStyle from './empty';
+import validateStyleMin from './validate_style.min';
+import Step from './expression/definitions/step';
+import {typeOf} from './expression/values';
+import FormatExpression from './expression/definitions/format';
+import Literal from './expression/definitions/literal';
+import CompoundExpression from './expression/compound_expression';
 
 const expression = {
     StyleExpression,
@@ -106,19 +126,63 @@ const visit = {eachSource, eachLayer, eachProperty};
 
 export {
     v8,
+    number,
+    interpolate,
+    Interpolate,
+    InterpolationType,
     latest,
     format,
+    emptyStyle,
     migrate,
+    expressions,
     derefLayers,
     diff,
+    diffOperations,
+    supportsPropertyExpression,
     ValidationError,
+    createExpression,
     ParsingError,
     expression,
     featureFilter,
+    FeatureState,
     convertFilter,
     Color,
+    Step,
+    CompoundExpression,
     Padding,
+    Formatted,
+    ResolvedImage,
     styleFunction as function,
     validate,
-    visit
+    visit,
+    Feature,
+    EvaluationContext,
+    GlobalProperties,
+    SourceExpression,
+    CompositeExpression,
+    FormattedSection,
+    IMercatorCoordinate,
+    ICanonicalTileID,
+    ILngLat,
+    ILngLatLike,
+    StyleExpression,
+    groupByLayout,
+    ZoomConstantExpression,
+    NullType,
+    validateStyleMin,
+    Type,
+    normalizePropertyExpression,
+    StylePropertyExpression,
+    isExpression,
+    ZoomDependentExpression,
+    FormattedType,
+    convertFunction,
+    isFunction, createFunction,
+    typeOf,
+    FormatExpression,
+    Literal,
+    createPropertyExpression,
+    StylePropertyFunction,
+    toString
+
 };

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -89,7 +89,7 @@ import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './til
 import EvaluationContext from './expression/evaluation_context';
 import {FormattedType, NullType, Type, toString} from './expression/types';
 
-import {number, color, array, padding} from './util/interpolate';
+import interpolates, {number, color, array, padding, interpolateFactory} from './util/interpolate';
 import expressions from './expression/definitions';
 import Interpolate from './expression/definitions/interpolate';
 import type {InterpolationType} from './expression/definitions/interpolate';
@@ -102,15 +102,6 @@ import {typeOf} from './expression/values';
 import FormatExpression from './expression/definitions/format';
 import Literal from './expression/definitions/literal';
 import CompoundExpression from './expression/compound_expression';
-
-const interpolateFactory = (interpolationType: 'number'|'color'|'array'|'padding') => {
-    switch (interpolationType) {
-        case 'number': return number;
-        case 'color': return color;
-        case 'array': return array;
-        case 'padding': return padding;
-    }
-};
 
 const expression = {
     StyleExpression,
@@ -166,8 +157,8 @@ export {
     latest,
 
     interpolateFactory,
+    interpolates,
     validate,
-    number as range,
     validateStyleMin,
     groupByLayout,
     emptyStyle,

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -31,7 +31,7 @@ class Color {
 
     /**
      * Parses valid CSS color strings and returns a `Color` instance.
-     * @param input
+     * @param input A valid CSS color string.
      * @returns A `Color` instance, or `undefined` if the input is not a valid color string.
      */
     static parse(input?: string | Color | null): Color | void {

--- a/src/util/interpolate.ts
+++ b/src/util/interpolate.ts
@@ -1,6 +1,15 @@
 import Color from './color';
 import Padding from './padding';
 
+export const interpolateFactory = (interpolationType: 'number'|'color'|'array'|'padding') => {
+    switch (interpolationType) {
+        case 'number': return number;
+        case 'color': return color;
+        case 'array': return array;
+        case 'padding': return padding;
+    }
+};
+
 export function number(a: number, b: number, t: number) {
     return (a * (1 - t)) + (b * t);
 }
@@ -30,3 +39,12 @@ export function padding(from: Padding, to: Padding, t: number): Padding {
         number(fromVal[3], toVal[3], t)
     ]);
 }
+
+const interpolates = {
+    number,
+    color,
+    array,
+    padding
+};
+
+export default interpolates;

--- a/src/util/interpolate.ts
+++ b/src/util/interpolate.ts
@@ -1,22 +1,22 @@
 import Color from './color';
 import Padding from './padding';
 
-export function range(a: number, b: number, t: number) {
+export function number(a: number, b: number, t: number) {
     return (a * (1 - t)) + (b * t);
 }
 
 export function color(from: Color, to: Color, t: number) {
     return new Color(
-        range(from.r, to.r, t),
-        range(from.g, to.g, t),
-        range(from.b, to.b, t),
-        range(from.a, to.a, t)
+        number(from.r, to.r, t),
+        number(from.g, to.g, t),
+        number(from.b, to.b, t),
+        number(from.a, to.a, t)
     );
 }
 
 export function array(from: Array<number>, to: Array<number>, t: number): Array<number> {
     return from.map((d, i) => {
-        return range(d, to[i], t);
+        return number(d, to[i], t);
     });
 }
 
@@ -24,9 +24,9 @@ export function padding(from: Padding, to: Padding, t: number): Padding {
     const fromVal = from.values;
     const toVal = to.values;
     return new Padding([
-        range(fromVal[0], toVal[0], t),
-        range(fromVal[1], toVal[1], t),
-        range(fromVal[2], toVal[2], t),
-        range(fromVal[3], toVal[3], t)
+        number(fromVal[0], toVal[0], t),
+        number(fromVal[1], toVal[1], t),
+        number(fromVal[2], toVal[2], t),
+        number(fromVal[3], toVal[3], t)
     ]);
 }

--- a/src/util/interpolate.ts
+++ b/src/util/interpolate.ts
@@ -1,22 +1,22 @@
 import Color from './color';
 import Padding from './padding';
 
-export function number(a: number, b: number, t: number) {
+export function range(a: number, b: number, t: number) {
     return (a * (1 - t)) + (b * t);
 }
 
 export function color(from: Color, to: Color, t: number) {
     return new Color(
-        number(from.r, to.r, t),
-        number(from.g, to.g, t),
-        number(from.b, to.b, t),
-        number(from.a, to.a, t)
+        range(from.r, to.r, t),
+        range(from.g, to.g, t),
+        range(from.b, to.b, t),
+        range(from.a, to.a, t)
     );
 }
 
 export function array(from: Array<number>, to: Array<number>, t: number): Array<number> {
     return from.map((d, i) => {
-        return number(d, to[i], t);
+        return range(d, to[i], t);
     });
 }
 
@@ -24,9 +24,9 @@ export function padding(from: Padding, to: Padding, t: number): Padding {
     const fromVal = from.values;
     const toVal = to.values;
     return new Padding([
-        number(fromVal[0], toVal[0], t),
-        number(fromVal[1], toVal[1], t),
-        number(fromVal[2], toVal[2], t),
-        number(fromVal[3], toVal[3], t)
+        range(fromVal[0], toVal[0], t),
+        range(fromVal[1], toVal[1], t),
+        range(fromVal[2], toVal[2], t),
+        range(fromVal[3], toVal[3], t)
     ]);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "checkJs": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "noEmit": false,
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
In order to hide the internal structure of this package, this exposes the functions needed in maplibre-gl-js, and bumps the verison with a prerelease