### PR TITLE
Minify style spec

### DIFF
--- a/build/rollup_plugin_minify_style_spec.ts
+++ b/build/rollup_plugin_minify_style_spec.ts
@@ -1,0 +1,25 @@
+import {Plugin} from 'rollup';
+
+function replacer(key: string, value: any) {
+    return (key === 'doc' || key === 'example' || key === 'sdk-support') ? undefined : value;
+}
+
+export default function minifyStyleSpec(): Plugin {
+    return {
+        name: 'minify-style-spec',
+        transform: (source, id) => {
+            if (!/reference[\\/]v[0-9]+\.json$/.test(id)) {
+                return;
+            }
+
+            const spec = JSON.parse(source);
+
+            delete spec['expression_name'];
+
+            return {
+                code: JSON.stringify(spec, replacer, 0),
+                map: {mappings: ''}
+            };
+        }
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.1",
+  "version": "18.0.1-pre.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.1",
+      "version": "18.0.1-pre.2",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.1",
+  "version": "18.0.1-pre.2",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -4,6 +4,7 @@ import {RollupOptions} from 'rollup';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import json from '@rollup/plugin-json';
+import minifyStyleSpec from './build/rollup_plugin_minify_style_spec';
 
 const config: RollupOptions[] = [{
     input: './src/style-spec.ts',
@@ -19,6 +20,7 @@ const config: RollupOptions[] = [{
         sourcemap: true
     }],
     plugins: [
+        minifyStyleSpec(),
         json(),
         resolve({
             browser: true,


### PR DESCRIPTION
The minification of the style spec should happen when the style-spec build is made, and not inside of maplibre-gl-js.

This takes ~ 100 kb off the bundle, from ~ 370 kb to ~ 270 kb for the .mjs