### PR TITLE
Compress style spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.2",
+  "version": "18.0.1-pre.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.2",
+      "version": "18.0.1-pre.3",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.2",
+  "version": "18.0.1-pre.3",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -5,6 +5,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import json from '@rollup/plugin-json';
 import minifyStyleSpec from './build/rollup_plugin_minify_style_spec';
+import terser from '@rollup/plugin-terser';
+import strip from '@rollup/plugin-strip';
 
 const config: RollupOptions[] = [{
     input: './src/style-spec.ts',
@@ -38,6 +40,18 @@ const config: RollupOptions[] = [{
             values: {
                 '_token_stack:': ''
             }
+        }),
+        strip({
+            sourceMap: true,
+            functions: ['PerformanceUtils.*', 'Debug.*']
+        }),
+        terser({
+            compress: {
+                // eslint-disable-next-line camelcase
+                pure_getters: true,
+                passes: 3
+            },
+            sourceMap: true
         }),
         typescript({
             compilerOptions: {


### PR DESCRIPTION
Add Terser and Strip rollup plugins.

Takes the bundle size from 270 kb to 116 kb

Maplibre GL JS also has Terser and Strip, but since this can be used independant of the maplibre-gl-js, it seems natural that this is also compressed on it's own.