### PR TITLE
Remove terser / strip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.3",
+  "version": "18.0.1-pre.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.3",
+      "version": "18.0.1-pre.4",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.3",
+  "version": "18.0.1-pre.4",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -41,18 +41,6 @@ const config: RollupOptions[] = [{
                 '_token_stack:': ''
             }
         }),
-        strip({
-            sourceMap: true,
-            functions: ['PerformanceUtils.*', 'Debug.*']
-        }),
-        terser({
-            compress: {
-                // eslint-disable-next-line camelcase
-                pure_getters: true,
-                passes: 3
-            },
-            sourceMap: true
-        }),
         typescript({
             compilerOptions: {
                 declaration: false,


### PR DESCRIPTION
The mangled plugin in pre.3 make issues with name imports like `import {Color} from '@maplibre...'`