### PR TITLE
export ColorType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.4",
+  "version": "18.0.1-pre.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.4",
+      "version": "18.0.1-pre.5",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.4",
+  "version": "18.0.1-pre.5",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -87,7 +87,7 @@ import validate from './validate_style';
 import {supportsPropertyExpression} from './util/properties';
 import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './tiles_and_coordinates';
 import EvaluationContext from './expression/evaluation_context';
-import {FormattedType, NullType, Type, toString} from './expression/types';
+import {FormattedType, NullType, Type, toString, ColorType} from './expression/types';
 
 import interpolates, {interpolateFactory} from './util/interpolate';
 import expressions from './expression/definitions';
@@ -157,7 +157,6 @@ export {
     latest,
 
     interpolateFactory,
-    interpolates,
     validate,
     validateStyleMin,
     groupByLayout,
@@ -178,6 +177,8 @@ export {
     typeOf,
     toString,
 
+    ColorType,
+    interpolates,
     v8,
     NullType,
     styleFunction as function,


### PR DESCRIPTION
The generate-style-code apparently only use ColorType. This PR allow all import statements from maplibre-gl-js to go towards @maplibre/maplibre-gl-style-spec