### PR TITLE
bump deps to match maplibre-gl-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.6",
+  "version": "18.0.1-pre.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.6",
+      "version": "18.0.1-pre.7",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/unitbezier": "^0.0.1",
         "@types/mapbox__point-geometry": "^0.1.2",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
+        "csscolorparser": "~1.0.3",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
       },
@@ -1258,9 +1258,9 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5513,9 +5513,9 @@
       "dev": true
     },
     "node_modules/json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.6",
+  "version": "18.0.1-pre.7",
   "author": "MapLibre",
   "keywords": [
     "mapbox",
@@ -41,11 +41,11 @@
   "dependencies": {
     "@mapbox/jsonlint-lines-primitives": "~2.0.2",
     "@mapbox/point-geometry": "^0.1.0",
-    "@mapbox/unitbezier": "^0.0.0",
+    "@mapbox/unitbezier": "^0.0.1",
     "@types/mapbox__point-geometry": "^0.1.2",
-    "csscolorparser": "~1.0.2",
-    "json-stringify-pretty-compact": "^2.0.0",
-    "minimist": "^1.2.5",
+    "csscolorparser": "~1.0.3",
+    "json-stringify-pretty-compact": "^4.0.0",
+    "minimist": "^1.2.8",
     "rw": "^1.3.3",
     "sort-object": "^0.3.2"
   },


### PR DESCRIPTION
Many of the deps are behind the version used in maplibre-gl-js. It makes it hard to compare the dev-builds. The deps mentioned in style-spec package.json were ignored previously, because the ones in maplibre-gl-js package.json were used instead.