### PR TITLE
Rollback json-stringify-pretty-compact to 3.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.7",
+  "version": "18.0.1-pre.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.7",
+      "version": "18.0.1-pre.8",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -14,7 +14,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@types/mapbox__point-geometry": "^0.1.2",
         "csscolorparser": "~1.0.3",
-        "json-stringify-pretty-compact": "^4.0.0",
+        "json-stringify-pretty-compact": "^3.0.0",
         "minimist": "^1.2.8",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
@@ -5513,9 +5513,9 @@
       "dev": true
     },
     "node_modules/json-stringify-pretty-compact": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.7",
+  "version": "18.0.1-pre.8",
   "author": "MapLibre",
   "keywords": [
     "mapbox",
@@ -44,7 +44,7 @@
     "@mapbox/unitbezier": "^0.0.1",
     "@types/mapbox__point-geometry": "^0.1.2",
     "csscolorparser": "~1.0.3",
-    "json-stringify-pretty-compact": "^4.0.0",
+    "json-stringify-pretty-compact": "^3.0.0",
     "minimist": "^1.2.8",
     "rw": "^1.3.3",
     "sort-object": "^0.3.2"


### PR DESCRIPTION
Version 4.x is EMS only, breaking the build pipeline of maplibre-gl-js for the CJS build