### PR TITLE
Don't export migrate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.8",
+  "version": "18.0.1-pre.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.8",
+      "version": "18.0.1-pre.9",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.8",
+  "version": "18.0.1-pre.9",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -67,7 +67,6 @@ import v8Spec from './reference/v8.json' assert {type: 'json'};
 const v8 = v8Spec as any;
 import latest from './reference/latest';
 import format from './format';
-import migrate from './migrate';
 import derefLayers from './deref';
 import diff, {operations} from './diff';
 import ValidationError from './error/validation_error';
@@ -162,7 +161,6 @@ export {
     groupByLayout,
     emptyStyle,
     format,
-    migrate,
     derefLayers,
     normalizePropertyExpression,
     isExpression,


### PR DESCRIPTION
migrate is only imported in the migrate unit tests, which now lives inside of style-spec, so there is no reason to export it.