### PR TITLE
Remove style-spec export of validate/format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.10",
+  "version": "18.0.1-pre.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.10",
+      "version": "18.0.1-pre.11",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.10",
+  "version": "18.0.1-pre.11",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -66,7 +66,6 @@ export type StylePropertySpecification = {
 import v8Spec from './reference/v8.json' assert {type: 'json'};
 const v8 = v8Spec as any;
 import latest from './reference/latest';
-import format from './format';
 import derefLayers from './deref';
 import diff, {operations} from './diff';
 import ValidationError from './error/validation_error';
@@ -82,7 +81,6 @@ import {createFunction, isFunction} from './function';
 import convertFunction from './function/convert';
 import {eachSource, eachLayer, eachProperty} from './visit';
 import ResolvedImage from './expression/types/resolved_image';
-import validate from './validate_style';
 import {supportsPropertyExpression} from './util/properties';
 import {IMercatorCoordinate, ICanonicalTileID, ILngLat, ILngLatLike} from './tiles_and_coordinates';
 import EvaluationContext from './expression/evaluation_context';
@@ -156,11 +154,9 @@ export {
     latest,
 
     interpolateFactory,
-    validate,
     validateStyleMin,
     groupByLayout,
     emptyStyle,
-    format,
     derefLayers,
     normalizePropertyExpression,
     isExpression,

--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -15,6 +15,6 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
 
     test('exports components directly, not behind `default` - https://github.com/mapbox/mapbox-gl-js/issues/6601', async  () => {
 
-        expect(await import('../../dist/index.cjs')).toHaveProperty('validate');
+        expect(await import('../../dist/index.cjs')).toHaveProperty('validateStyleMin');
     });
 });


### PR DESCRIPTION
validate / format are only used in the binaries, which will call into the specific files. This is to avoid validate/format end up in maplibre-gl-js bundle