### PR TITLE
separate-rollup-for-binaries

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -48,6 +48,9 @@ jobs:
           npm run build-style-spec
           npm run generate-typings
           npm run compile
+          npm run build-gl-style-format
+          npm run build-gl-style-migrate
+          npm run build-gl-style-validate
 
       - name: Build Release Notes
         id: release_notes

--- a/bin/gl-style-format.ts
+++ b/bin/gl-style-format.ts
@@ -2,7 +2,7 @@
 
 import fs from 'fs';
 import minimist from 'minimist';
-import format from '@maplibre/maplibre-gl-style-spec/tsc/src/format';
+import format from '../src/format';
 const argv = minimist(process.argv.slice(2));
 
 if (argv.help || argv.h || (!argv._.length && process.stdin.isTTY)) {

--- a/bin/gl-style-migrate.ts
+++ b/bin/gl-style-migrate.ts
@@ -2,8 +2,8 @@
 
 import fs from 'fs';
 import minimist from 'minimist';
-import format from '@maplibre/maplibre-gl-style-spec/tsc/src/format';
-import migrate from '@maplibre/maplibre-gl-style-spec/tsc/src/migrate';
+import format from '../src/format';
+import migrate from '../src/migrate';
 const argv = minimist(process.argv.slice(2));
 
 if (argv.help || argv.h || (!argv._.length && process.stdin.isTTY)) {

--- a/bin/gl-style-validate.ts
+++ b/bin/gl-style-validate.ts
@@ -3,7 +3,7 @@
 
 import minimist from 'minimist';
 import rw from 'rw';
-import validate from '@maplibre/maplibre-gl-style-spec/tsc/src/validate';
+import validate from '../src/validate_style';
 
 const argv = minimist(process.argv.slice(2), {
     boolean: 'json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "18.0.1-pre.12",
+  "version": "18.0.1-pre.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "18.0.1-pre.12",
+      "version": "18.0.1-pre.13",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -20,9 +20,9 @@
         "sort-object": "^0.3.2"
       },
       "bin": {
-        "gl-style-format": "bin/gl-style-format.js",
-        "gl-style-migrate": "bin/gl-style-migrate.js",
-        "gl-style-validate": "bin/gl-style-validate.js"
+        "gl-style-format": "dist/gl-style-format.js",
+        "gl-style-migrate": "dist/gl-style-migrate.js",
+        "gl-style-validate": "dist/gl-style-validate.js"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "18.0.1-pre.12",
+  "version": "18.0.1-pre.13",
   "author": "MapLibre",
   "keywords": [
     "mapbox",
@@ -18,6 +18,10 @@
   "type": "module",
   "scripts": {
     "build-style-spec": "rollup --configPlugin @rollup/plugin-typescript -c rollup.config.style-spec.ts",
+    "build-gl-style-format": "rollup --configPlugin @rollup/plugin-typescript -c rollup.config.gl-style-format.ts",
+    "build-gl-style-migrate": "rollup --configPlugin @rollup/plugin-typescript -c rollup.config.gl-style-migrate.ts",
+    "build-gl-style-validate": "rollup --configPlugin @rollup/plugin-typescript -c rollup.config.gl-style-validate.ts",
+    "build": "npm run build-style-spec && npm run build-gl-style-format && npm run build-gl-style-migrate && npm run build-gl-style-validate",
     "generate-style-spec": "ts-node build/generate-style-spec.ts",
     "generate-typings": "ts-node build/generate-typings.ts",
     "test-build": "jest --selectProjects=build",
@@ -34,9 +38,9 @@
     "url": "git@github.com:maplibre/maplibre-gl-style-spec.git"
   },
   "bin": {
-    "gl-style-migrate": "bin/gl-style-migrate.js",
-    "gl-style-validate": "bin/gl-style-validate.js",
-    "gl-style-format": "bin/gl-style-format.js"
+    "gl-style-migrate": "dist/gl-style-migrate.js",
+    "gl-style-validate": "dist/gl-style-validate.js",
+    "gl-style-format": "dist/gl-style-format.js"
   },
   "dependencies": {
     "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/rollup.config.gl-style-format.ts
+++ b/rollup.config.gl-style-format.ts
@@ -1,0 +1,44 @@
+import replace from '@rollup/plugin-replace';
+import commonjs from '@rollup/plugin-commonjs';
+import {RollupOptions} from 'rollup';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+import minifyStyleSpec from './build/rollup_plugin_minify_style_spec';
+
+const config: RollupOptions[] = [{
+    input: './bin/gl-style-format.ts',
+    output: [{
+        file: 'dist/gl-style-format.js',
+        format: 'es',
+        sourcemap: true
+    }],
+    plugins: [
+        minifyStyleSpec(),
+        json(),
+        resolve({
+            browser: true,
+            preferBuiltins: true,
+            // Some users reference modules within style-spec package directly, instead of the bundle
+            // This means that files within the style-spec package should NOT import files from the parent maplibre-gl-js tree.
+            // This check will cause the build to fail on CI allowing these issues to be caught.
+            jail: 'src/',
+        }),
+        // https://github.com/zaach/jison/issues/351
+        replace({
+            preventAssignment: true,
+            include: /\/jsonlint-lines-primitives\/lib\/jsonlint.js/,
+            delimiters: ['', ''],
+            values: {
+                '_token_stack:': ''
+            }
+        }),
+        typescript({
+            compilerOptions: {
+                declaration: false,
+            }
+        }),
+        commonjs()
+    ]
+}];
+export default config;

--- a/rollup.config.gl-style-migrate.ts
+++ b/rollup.config.gl-style-migrate.ts
@@ -1,0 +1,44 @@
+import replace from '@rollup/plugin-replace';
+import commonjs from '@rollup/plugin-commonjs';
+import {RollupOptions} from 'rollup';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+import minifyStyleSpec from './build/rollup_plugin_minify_style_spec';
+
+const config: RollupOptions[] = [{
+    input: './bin/gl-style-migrate.ts',
+    output: [{
+        file: 'dist/gl-style-migrate.js',
+        format: 'es',
+        sourcemap: true
+    }],
+    plugins: [
+        minifyStyleSpec(),
+        json(),
+        resolve({
+            browser: true,
+            preferBuiltins: true,
+            // Some users reference modules within style-spec package directly, instead of the bundle
+            // This means that files within the style-spec package should NOT import files from the parent maplibre-gl-js tree.
+            // This check will cause the build to fail on CI allowing these issues to be caught.
+            jail: 'src/',
+        }),
+        // https://github.com/zaach/jison/issues/351
+        replace({
+            preventAssignment: true,
+            include: /\/jsonlint-lines-primitives\/lib\/jsonlint.js/,
+            delimiters: ['', ''],
+            values: {
+                '_token_stack:': ''
+            }
+        }),
+        typescript({
+            compilerOptions: {
+                declaration: false,
+            }
+        }),
+        commonjs()
+    ]
+}];
+export default config;

--- a/rollup.config.gl-style-validate.ts
+++ b/rollup.config.gl-style-validate.ts
@@ -1,0 +1,44 @@
+import replace from '@rollup/plugin-replace';
+import commonjs from '@rollup/plugin-commonjs';
+import {RollupOptions} from 'rollup';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+import minifyStyleSpec from './build/rollup_plugin_minify_style_spec';
+
+const config: RollupOptions[] = [{
+    input: './bin/gl-style-validate.ts',
+    output: [{
+        file: 'dist/gl-style-validate.js',
+        format: 'es',
+        sourcemap: true
+    }],
+    plugins: [
+        minifyStyleSpec(),
+        json(),
+        resolve({
+            browser: true,
+            preferBuiltins: true,
+            // Some users reference modules within style-spec package directly, instead of the bundle
+            // This means that files within the style-spec package should NOT import files from the parent maplibre-gl-js tree.
+            // This check will cause the build to fail on CI allowing these issues to be caught.
+            jail: 'src/',
+        }),
+        // https://github.com/zaach/jison/issues/351
+        replace({
+            preventAssignment: true,
+            include: /\/jsonlint-lines-primitives\/lib\/jsonlint.js/,
+            delimiters: ['', ''],
+            values: {
+                '_token_stack:': ''
+            }
+        }),
+        typescript({
+            compilerOptions: {
+                declaration: false,
+            }
+        }),
+        commonjs()
+    ]
+}];
+export default config;


### PR DESCRIPTION
Fixes #18 , converting binaries to typescript and give them separate rollup bundles