### PR TITLE
fix: re-generate style specs before typecheck step

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - run: npm run generate-style-spec
       - run: npm run lint
         if: success() || failure()
       - run: npm run typecheck
@@ -37,7 +38,7 @@ jobs:
       - run: npm run jest-ci -- --selectProjects unit --testPathIgnorePatterns "/src/(gl|render|ui)/" 
       - run: npm run jest-ci -- --selectProjects integration --testPathIgnorePatterns "/test/integration/(query|browser|build)/"
   packaging-tests:
-    name: Packaging andd Build tests
+    name: Packaging and Build tests
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Add step in github hygiene job to re-generate style specs typing before running typecheck step

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
