### PR TITLE
Update V8 `metadata` documentation to reference maplibre

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -17,7 +17,7 @@
     },
     "metadata": {
       "type": "*",
-      "doc": "Arbitrary properties useful to track with the stylesheet, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'mapbox:'."
+      "doc": "Arbitrary properties useful to track with the stylesheet, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'maplibre:'."
     },
     "center": {
       "type": "array",
@@ -619,7 +619,7 @@
     },
     "metadata": {
       "type": "*",
-      "doc": "Arbitrary properties useful to track with the layer, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'mapbox:'."
+      "doc": "Arbitrary properties useful to track with the layer, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'maplibre:'."
     },
     "source": {
       "type": "string",


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

 - [x] Briefly describe the changes in this PR.
The description for `metadata` in the style spec (both for root & layers) gives an example referring to "mapbox" on how to use the `metadata` key in the style. This PR fixes that.   I have other documentation fixes forthcoming.

 - [x] Link to related issues. 
_None found in this new repo._

---

 - [x] Include before/after visuals or gifs if this PR includes visual changes.
_https://maplibre.org/maplibre-gl-js-docs/style-spec/root/#metadata refers to `mapbox`.  I am interested in updating this documentation to refer to MapLibre or other examples of `metadata`_

<img width="61.85%" alt="image" src="https://user-images.githubusercontent.com/118112/222034709-cedd2307-f1bf-47eb-80a6-3f873673e462.png">

---

 - [x] Write tests for all new functionality.
_I attempted to test with https://github.com/maplibre/maplibre-gl-js-docs/pull/419.  I am awaiting a stronger link between GL JS Docs and this new repo.  That is, changes in this repo should reflect directly into `maplibre/maplibre-gl-js-docs`._

 - [x] Document any changes to public APIs.
_`v8.json` is self documenting with GL JS Docs._

 - [x] Post benchmark scores. 
_n/a_

 - [x] Add an entry to `CHANGELOG.md` under the `## main` section. 
_n/a_
